### PR TITLE
🔐 Include SHA in FROM instruction

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/ministryofjustice/analytical-platform-airflow-python-base:1.7.0
+FROM ghcr.io/ministryofjustice/analytical-platform-airflow-python-base:1.7.0@sha256:5de4dfa5a59c219789293f843d832b9939fb0beb65ed456c241b21928b6b8f59
 
 # Below is an example of how to use the base image
 # COPY requirements.txt requirements.txt


### PR DESCRIPTION
## Proposed Changes

- Adds `sha256` of image, which :dependabot: Dependabot can update as well as the semver (see https://github.com/moj-analytical-services/analytical-platform-airflow-python-example/pull/6)

## Depends On

- https://github.com/ministryofjustice/analytical-platform-airflow-github-actions/pull/24

Signed-off-by: Jacob Woffenden <jacob.woffenden@justice.gov.uk>