### PR TITLE
⬆️ Bump to v7.0.0

### DIFF
--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -16,4 +16,4 @@ jobs:
     if: github.event.repository.private == false
     permissions:
       contents: read
-    uses: ministryofjustice/analytical-platform-airflow-github-actions/.github/workflows/shared-dependency-review.yml@ee7af2fc5379dc235ced9f93378cbca973d9e5ad # v6.0.0
+    uses: ministryofjustice/analytical-platform-airflow-github-actions/.github/workflows/shared-dependency-review.yml@613a7cc7496ddaed7ae2b12059177d8aeb0760ae # v7.0.0

--- a/.github/workflows/release-container.yml
+++ b/.github/workflows/release-container.yml
@@ -13,4 +13,4 @@ jobs:
     permissions:
       contents: read
       id-token: write
-    uses: ministryofjustice/analytical-platform-airflow-github-actions/.github/workflows/shared-release-container.yml@ee7af2fc5379dc235ced9f93378cbca973d9e5ad # v6.0.0
+    uses: ministryofjustice/analytical-platform-airflow-github-actions/.github/workflows/shared-release-container.yml@613a7cc7496ddaed7ae2b12059177d8aeb0760ae # v7.0.0

--- a/.github/workflows/scan-container.yml
+++ b/.github/workflows/scan-container.yml
@@ -11,10 +11,11 @@ permissions: {}
 jobs:
   scan-container:
     permissions:
+      actions: read
       contents: read
       id-token: write
       pull-requests: write
       security-events: write
-    uses: ministryofjustice/analytical-platform-airflow-github-actions/.github/workflows/shared-scan-container.yml@ee7af2fc5379dc235ced9f93378cbca973d9e5ad # v6.0.0
+    uses: ministryofjustice/analytical-platform-airflow-github-actions/.github/workflows/shared-scan-container.yml@613a7cc7496ddaed7ae2b12059177d8aeb0760ae # v7.0.0
     with:
       runtime: python

--- a/.github/workflows/test-container.yml
+++ b/.github/workflows/test-container.yml
@@ -14,4 +14,4 @@ jobs:
       contents: read
       id-token: write
       pull-requests: write
-    uses: ministryofjustice/analytical-platform-airflow-github-actions/.github/workflows/shared-test-container.yml@ee7af2fc5379dc235ced9f93378cbca973d9e5ad # v6.0.0
+    uses: ministryofjustice/analytical-platform-airflow-github-actions/.github/workflows/shared-test-container.yml@613a7cc7496ddaed7ae2b12059177d8aeb0760ae # v7.0.0


### PR DESCRIPTION
## Proposed Changes

- Bump GitHub Actions to [v7.0.0](https://github.com/ministryofjustice/analytical-platform-airflow-github-actions/releases/tag/v7.0.0) 

Signed-off-by: Jacob Woffenden <jacob.woffenden@justice.gov.uk>